### PR TITLE
Update README to include statement for Opera

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Tested with latest Chrome (25), Safari (6), IE (10).
 - For 32-bit browsers, like Chrome, **the entire browser may crash** before the disk is filled.
 - Does not work on Firefox, since Firefox's implementation of localStorage is smarter.
+- Requires user input on Opera - it asks you how much you want to allow each subdomain.
 - Includes a button to reclaim your disk space ;)
 
 ## How it works


### PR DESCRIPTION
Opera asks you how much storage you want to allow the website, which blocks the call to localStorage. Once you specify an amount, the dialog for `2.filldisk.com` pops up. It requires user input for every 5 (or 10) MB.
