### PR TITLE
Opera Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 ## Features:
 
-- Fills up the user's hard disk on Chrome, Safari, and IE.
+- Fills up the user's hard disk on Chrome, Safari, Opera and IE.
 - Fills up **1 GB every 16 seconds** on my Macbook Pro Retina (with solid state drive)
-- Tested with latest Chrome (25), Safari (6), IE (10).
+- Tested with latest Chrome (25), Safari (6), Opera (12), IE (10).
 - For 32-bit browsers, like Chrome, **the entire browser may crash** before the disk is filled.
 - Does not work on Firefox, since Firefox's implementation of localStorage is smarter.
 - Includes a button to reclaim your disk space ;)

--- a/static/frame.html
+++ b/static/frame.html
@@ -53,6 +53,7 @@
     var n1kb = repeat(n100b, 10)
     var n10kb = repeat(n1kb, 10)
     var n100kb = repeat(n10kb, 10)
+    var n999kb = repeat(n1kb, 999)
     var n2500kb = repeat(n100kb, 25)
 
     /**
@@ -66,7 +67,15 @@
         localStorage['filldisk'] = ''
         localStorage.removeItem('filldisk')
       } else {
-        localStorage['filldisk'] = n2500kb
+        /**
+         * Opera has a limit of slightly less than 2MB
+         * above which it asks for user confirmation.
+         */
+        if (navigator.userAgent.indexOf("Opera") == -1) {
+          localStorage['filldisk'] = n2500kb
+        } else {
+          localStorage['filldisk'] = n999kb
+        }
       }
     } catch (e) {
       console.error('local storage exception')

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
 
 <button class="reclaim">Stop the madness!</button> (gives your disk space back)
 
-<p>Works in Chrome, Safari (iOS and desktop), and IE. Firefox is immune to this hackery.</p>
+<p>Works in Chrome, Safari (iOS and desktop), Opera and IE. Firefox is immune to this hackery.</p>
 
 <p>Read about <a href="http://feross.org/fill-disk/">how this works</a>. Hacked by <a href="http://feross.org">Feross</a>.</p>
 

--- a/static/index.js
+++ b/static/index.js
@@ -25,8 +25,16 @@ function onMessage (event) {
   /**
    * Calculate the amount of used space in MB
    */
-
-  var usedMB = (frameNum * 5) - 5
+  var usedMB
+  if (navigator.userAgent.indexOf("Opera") == -1) {
+    usedMB = (frameNum * 5) - 5
+  } else {
+    /**
+     * Opera's growth is slightly less than 2MB per frame,
+     * but this is a close enough approximation.
+     */
+    usedMB = (frameNum * 2) - 2
+  }
   mb.innerHTML = usedMB
 
   /**


### PR DESCRIPTION
Opera has a lower effective limit of 2MB above which it will prompt the user. This patch just lowers the amount of space consumed by each invocation from 5MB to 2MB to get around this limit.
